### PR TITLE
Hotfix/flow correction

### DIFF
--- a/controllers/LoadController.php
+++ b/controllers/LoadController.php
@@ -123,20 +123,18 @@ class LoadController extends Controller
      * @param string $school
      * @return array
      */
-    private function getEnrollmentsTAG($classroom){
+    private function getEnrollmentsTAG($classroom, $year){
         /** HB              TAG
          * enrollment  to   student_enrollment
          * id               null
          * student          student_fk
          * classroom        classroom_fk
          */
-        $query = "select 'null' as id, student_fk as student, classroom_fk as classroom "
+        $query = "select 'null' as id, student_enrollment.student_fk as student, student_enrollment.classroom_fk as classroom "
         . "from student_enrollment "
-
-
-
         ."join student_identification  on student_identification.id = student_enrollment.student_fk "
-        . "where classroom_fk = " . $classroom;
+        ."join classroom on classroom.id =  student_enrollment.classroom_fk "
+        . "where classroom.id = " . $classroom . " and classroom.school_year = ".$year." and (student_enrollment.status = 1 or student_enrollment.status is null)";
 
         $result = Yii::$app->tag->createCommand($query);
         return $result->queryAll();
@@ -241,7 +239,7 @@ class LoadController extends Controller
 
             $response[$newClassroom->name] = $newClassroom->id;
             if ($newClassroom['fid'] != null) {
-                $enrollments = $this->getEnrollmentsTAG($newClassroom->fid);
+                $enrollments = $this->getEnrollmentsTAG($newClassroom->fid, $cid);
                 foreach ($enrollments as $enrollment) {
                     $student = $this->getStudentsTAG($enrollment['student']);
         

--- a/controllers/ReportsController.php
+++ b/controllers/ReportsController.php
@@ -493,7 +493,8 @@ class ReportsController extends \yii\web\Controller {
         /* @var $student \app\models\student */
         $name = $student != null ? $student->name : "____________________________________________________________________";
         $gender = $student->gender;
-        echo $this->actionGetConsultationLetterRaw($name, $gender, $date, $time, $place);
+        $consultationLetter = $this->actionGetConsultationLetterRaw($name, $gender, $date, $time, $place);
+        Yii::$app->response->content = $consultationLetter;
     }
     
     public function actionGetConsultationLetterRaw($name, $gender, $date, $time, $place){

--- a/controllers/ReportsController.php
+++ b/controllers/ReportsController.php
@@ -95,7 +95,7 @@ class ReportsController extends \yii\web\Controller {
         $sex = $student != null ? \yii::t('app', $student->gender) : "";
         $weight = $anatomy != null ? $anatomy->weight . "kg" : "";
         $height = $anatomy != null ? $anatomy->height . "m" : "";
-        $imc = $anatomy != null ? number_format($weight / ($height * $height), 2) : "";
+        $imc = $anatomy != null ? number_format($anatomy->weight / $anatomy->height**2, 2) : "";
         $rate1 = $hb1 != null ? $hb1->rate . "g/dL" : "";
 
         if ($anatomy == null) {

--- a/controllers/ReportsController.php
+++ b/controllers/ReportsController.php
@@ -240,7 +240,7 @@ class ReportsController extends \yii\web\Controller {
         $sex = $student != null ? \yii::t('app', $student->gender) : "";
         $weight = $anatomy != null ? $anatomy->weight . "kg" : "";
         $height = $anatomy != null ? $anatomy->height . "m" : "";
-        $imc = $anatomy != null ? number_format($weight / ($height * $height), 2) : "";
+        $imc = $anatomy != null ? number_format($anatomy->weight / ($anatomy->height**2), 2) : "";
         $rate1 = $hb1 != null ? $hb1->rate . "g/dL" : "";
         $sulfato ='';
         $vermifugo ='';
@@ -254,7 +254,7 @@ class ReportsController extends \yii\web\Controller {
             $gotasPorML = 20;
             $concentracaoPorGota = $concentracaoPorML / $gotasPorML;
 
-            $posologia = ceil($weight / $concentracaoPorGota);
+            $posologia = ceil($anatomy->weight / $concentracaoPorGota);
 
 
 //            $gotasPor3 = $concentracaoPorGota/3;

--- a/models/campaign.php
+++ b/models/campaign.php
@@ -265,8 +265,8 @@ class campaign extends \yii\db\ActiveRecord {
             sum((SELECT count(1) from anatomy a2 WHERE a2.student = s.id and a2.`date` >= c.`begin` GROUP by a2.student)) as anatomy_updated
         FROM campaign c 
             join term t on t.campaign = c.id 
-            join enrollment e on e.id = t.enrollment
-            join student s on s.id = e.student
+            left join enrollment e on e.id = t.enrollment
+            left join student s on s.id = e.student
             left join hemoglobin h1 on h1.agreed_term = t.id AND  h1.sample = 1
             left join hemoglobin h2 on h2.agreed_term = t.id AND  h1.sample = 2
             left join hemoglobin h3 on h3.agreed_term = t.id AND  h1.sample = 3

--- a/views/consultation/_form.php
+++ b/views/consultation/_form.php
@@ -29,7 +29,7 @@ use kartik\select2\Select2;
                 'type' => Form::INPUT_WIDGET,
                 'widgetClass' => Select2::class,
                 'options' => [
-                    'data' => ["aaaaa"],//ArrayHelper::map($campaign->getHemoglobinsWithoutConsult()->all(), 'agreed_term', 'agreedTerm.students.name'),
+                    'data' => ArrayHelper::map($campaign->getHemoglobinsWithoutConsult()->all(), 'agreed_term', 'agreedTerm.students.name'),
                     'options' => [
                         'placeholder' => Yii::t('app', 'Select Student...'),
                         $model->isNewRecord ? "" : "disabled" => "disabled"

--- a/views/consultation/index.php
+++ b/views/consultation/index.php
@@ -35,11 +35,11 @@ $this->params['campaign'] = $campaign;
 <div class="consultation-index">
 
     <?=Html::a(Icon::show('file-pdf-o', [], Icon::FA).yii::t('app','All Prescriptions...'),['reports/multiple-prescriptions', 'cid'=>$campaign],
-         ['target'=>'_blank', 'class' => 'btn btn-primary pull-right']) ?>
+         ['target'=>'_blank', 'class' => 'btn btn-primary pull-right', 'style' => 'display:none']) ?>
     <br>
     <br>
     <?=Html::a(Icon::show('file-pdf-o', [], Icon::FA).yii::t('app','All Letters/Anamnese...'),'#',
-         ['id'=>'selectLetterOptions', 'class' => 'btn btn-primary pull-right']) ?>
+         ['id'=>'selectLetterOptions', 'class' => 'btn btn-primary pull-right', 'style' => 'display:none']) ?>
     <br>
     <br>
     <?= GridView::widget([

--- a/views/hemoglobin/_form.php
+++ b/views/hemoglobin/_form.php
@@ -1,5 +1,6 @@
 <?php
 
+use kartik\widgets\Alert;
 use yii\helpers\Html;
 use \yii\helpers\ArrayHelper;
 use kartik\widgets\ActiveForm;
@@ -55,6 +56,14 @@ $this->assetBundles['Hemoglobin']->js = [
                 . "</thead>"
                 . "<tbody></tbody>"
                 . "</table>";
+        echo Alert::widget([
+            'options' => [
+                'id' => 'noHemoglobinsMessage',
+                'class' => 'alert alert-danger',
+                'style' => 'display:none;',
+            ],
+            'body' => 'Todos os alunos que aderiram a campanha dessa turma tiveram suas hemoglobinas coletadas'
+        ]);
         echo Html::submitButton(Yii::t('app', 'Create'), ['id'=>'send', "style"=>"display:none",  'class' =>'btn btn-success']);
    
     } else {

--- a/views/hemoglobin/index.php
+++ b/views/hemoglobin/index.php
@@ -71,7 +71,7 @@ $columns = array_merge($columns, [[
 
 <div class="hemoglobin-index">
     <?=Html::a(Icon::show('file-pdf-o', [], Icon::FA).yii::t('app','Anemics Lists...'),Url::toRoute(['anemics-lists', 'cid' => $campaign->id, 's' => $sample ]),
-         ['target'=>'_blank', 'id'=>'anemicsLists', 'class' => 'btn btn-primary pull-right']) ?>
+         ['target'=>'_blank', 'id'=>'anemicsLists', 'class' => 'btn btn-primary pull-right', 'style' => 'display:none']) ?>
     <br>
     <br>
 

--- a/views/reports/anamnese.php
+++ b/views/reports/anamnese.php
@@ -142,7 +142,9 @@ $this->assetBundles['Reports']->js = [
 
     <div class="report-content">
         <div class="report-head">
-            
+            <div class="pull-right hidden-print">
+                <?=Html::button(Icon::show('print',[], Icon::FA).Yii::t('app', 'Print'), ['id'=>'print-button', 'class'=>'btn btn-primary fixed-btn', 'onclick'=>'window.print()'])?>
+            </div>
             <?= ReportHeaderWidget::widget(); ?>
             <h4 class="report-title">Questionário de Anamnese</h4>
         </div>
@@ -450,8 +452,4 @@ exame clínico.  Caso apareça uma opção ou 2 <img width="20" src="<?php echo 
         
         
     </div> <!-- .report-content -->
-
-    <div class="pull-right hidden-print">
-    <?=Html::button(Icon::show('print',[], Icon::FA).Yii::t('app', 'Print'), [ 'id' =>'print-button', 'class'=>'btn btn-primary', 'onclick'=>'window.print()'])?>
-    </div>
 </div>

--- a/views/reports/consultationLetter.php
+++ b/views/reports/consultationLetter.php
@@ -161,6 +161,9 @@ $this->assetBundles['Reports']->js = [
     </div>
     <div class="report-content">
         <div class="report-head">
+            <div class="pull-right hidden-print">
+                <?=Html::button(Icon::show('print',[], Icon::FA).Yii::t('app', 'Print'), ['id'=>'print-button', 'class'=>'btn btn-primary fixed-btn', 'onclick'=>'window.print()'])?>
+            </div>
             <?= ReportHeaderWidget::widget() ?>
             <h4 class="report-title">Carta de Aviso de Consulta</h4>
         </div>
@@ -183,8 +186,5 @@ $this->assetBundles['Reports']->js = [
             Com estas medidas podemos ajudar as nossas crianças a ficarem sempre saudáveis e alegres.<br/><br/>
         </div>
         <div id="report-footer">Muito obrigado pela atenção.</div>
-    </div>
-    <div class="pull-right hidden-print">
-    <?=Html::button(Icon::show('print',[], Icon::FA).Yii::t('app', 'Print'), ['id'=>'print-button', 'class'=>'btn btn-primary', 'onclick'=>'window.print()'])?>
     </div>
 </div>

--- a/views/reports/health.php
+++ b/views/reports/health.php
@@ -1,8 +1,11 @@
 <?php
+use yii\helpers\Html;
+use kartik\icons\Icon;
 $this->title = yii::t('app', 'Health Report');
 ?>
-
-<i class="print-health-report fa fa-print" onclick="window.print()"></i>
+<div class="pull-right hidden-print">
+    <?=Html::button(Icon::show('print',[], Icon::FA).Yii::t('app', 'Print'), ['id'=>'print-button', 'class'=>'btn btn-primary fixed-btn', 'onclick'=>'window.print()'])?>
+</div>
 <br/>
 
 <div class="row" id="health-header">

--- a/views/reports/health.php
+++ b/views/reports/health.php
@@ -22,7 +22,7 @@ $this->title = yii::t('app', 'Health Report');
         <th class='border-right'>ALUNOS MATRICULADOS</th>
         <th class='border-right'>ANTROPOMETRIA</th>
         <th class='border-right'>TERMOS DE CONSENTIMENTO ASSINADOS</th>
-        <th class='border-right color-grey'>FERRITINA</th>
+<!--        <th class='border-right color-grey'>FERRITINA</th>-->
         <th class='border-right color-grey' style="-webkit-print-color-adjust: exact;">HB1</th>
         <th class='border-right'>ANÊMICO HB1</th>
         <th class='border-right'>RECEBERAM MEDICAMENTO</th>
@@ -125,15 +125,15 @@ $this->title = yii::t('app', 'Health Report');
                     ?>%)
                 </span>
             </td>
-            <td class="border-bottom-dashed-right color-grey">
-                <?= $ferritin['Done'] ?>
-                <span class="health-report-percent">
-                    (<?=
-                    $ferritin['Done'] == 0 ? ($terms['Agreed'] == 0 ? 100 : 0) :
-                        round(($ferritin['Done'] / $terms['Agreed']) * 100, 2)
-                    ?>%)
-                </span>
-            </td>
+<!--            <td class="border-bottom-dashed-right color-grey">-->
+<!--                --><?php //= $ferritin['Done'] ?>
+<!--                <span class="health-report-percent">-->
+<!--                    (--><?php //=
+//                    $ferritin['Done'] == 0 ? ($terms['Agreed'] == 0 ? 100 : 0) :
+//                        round(($ferritin['Done'] / $terms['Agreed']) * 100, 2)
+//                    ?><!--%)-->
+<!--                </span>-->
+<!--            </td>-->
             <td class="border-bottom-dashed-right color-grey">
                 <?= $hb1['Total'] ?>
                 <span class="health-report-percent">

--- a/views/reports/prescription.php
+++ b/views/reports/prescription.php
@@ -17,8 +17,8 @@ use app\components\PrescriptionWidget;
 $this->title = yii::t('app', 'Prescription');
 ?>
 
-<?php  echo PrescriptionWidget::widget(['student' => $student, 'sulfato'=> $sulfato, 'vermifugo' => $vermifugo]); ?>
+<div class="pull-right hidden-print">
+    <?=Html::button(Icon::show('print',[], Icon::FA).Yii::t('app', 'Print'), ['id'=>'print-button', 'class'=>'btn btn-primary fixed-btn', 'onclick'=>'window.print()'])?>
+</div>
 
-    <div class="pull-right hidden-print">
-    <?=Html::button(Icon::show('print',[], Icon::FA).Yii::t('app', 'Print'), [ 'id' =>'print-button', 'class'=>'btn btn-primary', 'onclick'=>'window.print()'])?>
-    </div>
+<?php  echo PrescriptionWidget::widget(['student' => $student, 'sulfato'=> $sulfato, 'vermifugo' => $vermifugo]); ?>

--- a/views/site/index.php
+++ b/views/site/index.php
@@ -57,26 +57,6 @@ $this->params['siteIndex'] = true;
                         'class'=>'updateCampaign campaign-box-edit',
                         'for'=>'#'
                     ]);?>
-                    <div id="campaing-box[<?= $campaign_resume['campaing']['Id'] ?>]-anatomies" class="campaign-box-container">
-                        <div class="campaign-box-label"><?= Html::a(Yii::t('app', 'Ferritin').': ',$campaign_resume['ferritin'] ['Url'])?></div>
-                        <div class="campaign-box-content">
-                        <?= Html::a($campaign_resume['ferritin']['Done'].' '.Icon::show('check', ['class'=>'icon-sucess']),
-                                    $campaign_resume['ferritin']['Url'])?>&nbsp;
-                            <?= Html::a($campaign_resume['ferritin']['UnDone'].' '.Icon::show('remove', ['class'=>'icon-error']),
-                                    $campaign_resume['ferritin']['Url'])?>
-                        </div>
-                    </div><!-- end ferritin -->
-                    <div id="campaing-box[<?= $campaign_resume['campaing']['Id'] ?>]-anatomies" class="campaign-box-container">
-                        <div class="campaign-box-label"><?= Html::a(Yii::t('app', 'Anatomies').': ',$campaign_resume['anatomies']['Url'])?></div>
-                        <div class="campaign-box-content">
-                            <?= Html::a($campaign_resume['anatomies']['OutOfDate'].' '.Icon::show('info', ['class'=>'icon-info']),
-                                    $campaign_resume['anatomies']['Url'])?>&nbsp;
-                            <?= Html::a($campaign_resume['anatomies']['Updated'].' '.Icon::show('check', ['class'=>'icon-sucess']),
-                                    $campaign_resume['anatomies']['Url'])?>&nbsp;
-                            <?= Html::a($campaign_resume['anatomies']['Unknown'].' '.Icon::show('remove', ['class'=>'icon-error']),
-                                    $campaign_resume['anatomies']['Url'])?>
-                        </div>
-                    </div><!-- end anatomies -->
                     <div id="campaing-box[<?= $campaign_resume['campaing']['Id'] ?>]-terms" class="campaign-box-container">
                         <div class="campaign-box-label"><?= Html::a(Yii::t('app_v2', 'Terms').': ',$campaign_resume['terms']['Url'])?></div>
                         <div class="campaign-box-content">
@@ -86,7 +66,26 @@ $this->params['siteIndex'] = true;
                                     $campaign_resume['terms']['Url'])?>
                         </div>
                     </div> <!-- end terms -->
-                    
+                    <div id="campaing-box[<?= $campaign_resume['campaing']['Id'] ?>]-anatomies" class="campaign-box-container">
+                        <div class="campaign-box-label"><?= Html::a(Yii::t('app', 'Anatomies').': ',$campaign_resume['anatomies']['Url'])?></div>
+                        <div class="campaign-box-content">
+                            <?= Html::a($campaign_resume['anatomies']['OutOfDate'].' '.Icon::show('info', ['class'=>'icon-info']),
+                                $campaign_resume['anatomies']['Url'])?>&nbsp;
+                            <?= Html::a($campaign_resume['anatomies']['Updated'].' '.Icon::show('check', ['class'=>'icon-sucess']),
+                                $campaign_resume['anatomies']['Url'])?>&nbsp;
+                            <?= Html::a($campaign_resume['anatomies']['Unknown'].' '.Icon::show('remove', ['class'=>'icon-error']),
+                                $campaign_resume['anatomies']['Url'])?>
+                        </div>
+                    </div><!-- end anatomies -->
+<!--                    <div id="campaing-box[--><?php //= $campaign_resume['campaing']['Id'] ?><!--]-anatomies" class="campaign-box-container">-->
+<!--                        <div class="campaign-box-label">--><?php //= Html::a(Yii::t('app', 'Ferritin').': ',$campaign_resume['ferritin'] ['Url'])?><!--</div>-->
+<!--                        <div class="campaign-box-content">-->
+<!--                            --><?php //= Html::a($campaign_resume['ferritin']['Done'].' '.Icon::show('check', ['class'=>'icon-sucess']),
+//                                $campaign_resume['ferritin']['Url'])?><!--&nbsp;-->
+<!--                            --><?php //= Html::a($campaign_resume['ferritin']['UnDone'].' '.Icon::show('remove', ['class'=>'icon-error']),
+//                                $campaign_resume['ferritin']['Url'])?>
+<!--                        </div>-->
+<!--                    </div> end ferritin -->
                     <div id="campaing-box[<?= $campaign_resume['campaing']['Id'] ?>]-hb1" class="campaign-box-container">
                         <div class="campaign-box-label"><?= Html::a(Yii::t('app', 'HB1').': ',$campaign_resume['hb1']['Url'])?></div>
                         <div class="campaign-box-content">

--- a/views/term/index.php
+++ b/views/term/index.php
@@ -32,19 +32,19 @@ $this->params['campaign'] = $campaign;
 
 <div class="term-index">
     <?=Html::a(Icon::show('file-pdf-o', [], Icon::FA).yii::t('app','All Terms'). ' PDF',Url::toRoute(['reports/build-terms', 'cid' => $campaign]),
-         ['target'=>"_blank", 'class' => 'btn btn-primary pull-right']) ?>
-    <br>
-    <br>
+         ['target'=>"_blank", 'class' => 'btn btn-primary pull-right', 'style' => 'display:none']) ?>
+<!--    <br>-->
+<!--    <br>-->
     <?=Html::a(Icon::show('file-pdf-o', [], Icon::FA).yii::t('app','All Terms'),Url::toRoute(['reports/build-terms-html', 'cid' => $campaign]),
          ['target'=>"_blank", 'class' => 'btn btn-primary pull-right']) ?>
-    <br>
-    <br>
+<!--    <br>-->
+<!--    <br>-->
     <?=Html::a(Icon::show('file-pdf-o', [], Icon::FA).yii::t('app','All Terms - Weight and Height'),Url::toRoute(['reports/weight-height', 'cid' => $campaign]),
-        ['target'=>"_blank", 'class' => 'btn btn-primary pull-right']) ?>
-    <br>
-    <br>
+        ['target'=>"_blank", 'class' => 'btn btn-primary pull-right', 'style' => 'display:none']) ?>
+<!--    <br>-->
+<!--    <br>-->
     <?=Html::a(Icon::show('file-pdf-o', [], Icon::FA).yii::t('app','Agreed Terms...'),'#',
-         ['id'=>'selectSchoolButton', 'class' => 'btn btn-primary pull-right']) ?>
+         ['id'=>'selectSchoolButton', 'class' => 'btn btn-primary pull-right', 'style' => 'display:none']) ?>
     
     <br>
     <br>

--- a/web/css/reports.css
+++ b/web/css/reports.css
@@ -710,7 +710,7 @@ awnser{
 
 .fixed-btn{
     position: fixed;
-    bottom: 25px;
+    /*bottom: 25px;*/
     right: 25px;
 }
 

--- a/web/scripts/HemoglobinView/Click.js
+++ b/web/scripts/HemoglobinView/Click.js
@@ -10,14 +10,13 @@ $("#classrooms").change(function () {
     var sample = $(this).attr("sample");
     var url = "";
     var {origin,pathname} = window.location;
+    $("#noHemoglobinsMessage").hide();
     if (sample == 1) {
         url = `${origin}${pathname}?r=hemoglobin%2Fget-agreed-terms&clid=${clid}&cid=${cid}&samp=${sample}`;
     }
     else {
         url = `${origin}${pathname}?r=hemoglobin%2Fget-attended-consults&clid=${clid}&cid=${cid}&samp=${sample}`;
     }
-
-    console.log(url)
     
     $.ajax({
         url: url,
@@ -31,7 +30,11 @@ $("#classrooms").change(function () {
                 + "<tr>";
         });
         $("#hemoglobins tbody").append(html);
-        $("#send").show();
+        if(html.length > 0) {
+            $("#send").show();
+        }else {
+            $("#noHemoglobinsMessage").show();
+        }
     }).fail(function(){
         $("#hemoglobins tbody").empty();
         $("#send").hide();


### PR DESCRIPTION
## Pull Request - HB Change Documentation

### Correction in campaigns query
The query responsible for displaying the campaigns was corrected to display the campaigns even when no terms are adhered. Previously, display was conditional on there being at least one opt-in term, which resulted in an empty list of campaigns when no terms were present. Now, regardless of the existence of adhered terms, the campaigns will be correctly displayed.

### Bug fix in queries
A bug related to queries has been identified and fixed. The bug was causing errors when creating a new query.

### TAG import without repeated registrations
During TAG import, an issue with the presence of repeated license plates has been resolved. Previously, the import of the TAG was allowing the presence of duplicate registrations, which resulted in redundant records in the system. The import process has now been updated to check for and remove duplicate license plates, ensuring that only a single occurrence of each license plate is imported correctly.

> These changes were implemented to improve the stability and accuracy of the HB system, providing a more consistent and reliable experience for users.