### PR TITLE
fix/text-sucess

### DIFF
--- a/banco/2024-03-26-delete-duplicate-term.sql
+++ b/banco/2024-03-26-delete-duplicate-term.sql
@@ -1,0 +1,9 @@
+CREATE TEMPORARY TABLE TEMP_TBL
+select min(id) from term t
+group by t.campaign, t.enrollment
+HAVING COUNT(1) > 1;
+
+
+DELETE FROM term WHERE id in(
+SELECT * from temp_tbl
+);


### PR DESCRIPTION
## 💡Motivação
Na maioria dos alunos, não é possível marcar a opção “Compareceu” e “Recebeu”. 

Já os alunos que é possível marcar a opção “Compareceu” e “Recebeu”, não consigo desfazer a opção, caso eu marque algum aluno errado. 

## 💡Alterações Realizadas
- Criada uma migration para deletar os alunos com termos de consultas duplicados.

## 💡Fluxo de Testes
- Clicar no compareceu e recebeu e funcionar.

## 💡Migrations Utilizadas
2024-03-26-delete-duplicate-term
