### PR TITLE
Feat/delete_consultation

### DIFF
--- a/assets/AppAsset.php
+++ b/assets/AppAsset.php
@@ -22,6 +22,7 @@ class AppAsset extends AssetBundle
         'css/login.css',
         'css/select2.css',
         'css/reports.css',
+        'css/consultation.css',
     ];
     public $js = [
         

--- a/controllers/ConsultationController.php
+++ b/controllers/ConsultationController.php
@@ -119,8 +119,6 @@ class ConsultationController extends Controller {
      */
     public function actionDelete($id) {
         $this->findModel($id)->delete();
-
-        return $this->redirect(['index']);
     }
 
     /**

--- a/views/consultation/index.php
+++ b/views/consultation/index.php
@@ -117,7 +117,33 @@ $this->params['campaign'] = $campaign;
                     }
                     return "";
                 }
-            ]
+            ],
+            [
+                'class' => kartik\grid\DataColumn::class,
+                'label' => yii::t('app', 'Delete'),
+                'options' => ['style' => 'width:10%'],
+                'content' => function($model, $key, $index, $column) {
+                    $cid = $this->params['campaign'];
+                    $consult = $model->getTerms()->where("campaign = :cid", ["cid" => $cid])->one()->getConsults()->one();
+
+                    $deleteUrl = Url::toRoute(['consultation/delete', 'id' => $consult->id]);
+
+                    $deleteButton = Html::a(
+                        Icon::show('trash-o', [], Icon::FA),
+                        $deleteUrl,
+                        [
+                            'class' => 'delete-consult',
+                            'data' => [
+                                'method' => 'post',
+                                'confirm' => 'Você tem certeza que deseja excluir este item?',
+                                'ajax' => '1'
+                            ],
+                        ]
+                    );
+
+                    return "<br>" . $deleteButton;
+                }
+            ],
         ],
         'pjax' => true,
         'pjaxSettings' => [

--- a/web/css/consultation.css
+++ b/web/css/consultation.css
@@ -7,3 +7,7 @@ th {
     flex-direction: column;
     text-align: center;
 }
+
+.delete-consult > i {
+    color: #a94442
+}

--- a/web/css/consultation.css
+++ b/web/css/consultation.css
@@ -1,0 +1,9 @@
+th {
+    text-align: center;
+}
+
+.delete-consult {
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+}

--- a/web/scripts/ConsultationView/Functions.js
+++ b/web/scripts/ConsultationView/Functions.js
@@ -26,3 +26,25 @@ function submitUpdateAttended(cid){
     });
     
 }
+
+$(document).ready(function() {
+    $('.delete-consult').on('click', function(e) {
+        e.preventDefault();
+
+        var url = $(this).attr('href');
+
+        $.ajax({
+            url: url,
+            type: 'POST',
+            success: function(response) {
+                // Recarrega a página para a URL atual
+                window.location.reload();
+            },
+            error: function(xhr, status, error) {
+                console.error('Erro na exclusão:', status, error);
+            }
+        });
+
+        return false;
+    });
+});


### PR DESCRIPTION
## 💡Motivação
Era possivel cadastrar consultas mesmo o aluno sem ser anemico. Seria necessário criar um botao para excluir essas consultas.

## 💡Alterações Realizadas
- Adicionada coluna de exclusão na tela de consultas, para cada consulta de aluno.
- Modificada a action de delete das consultas, tirando o redirecionamento do index.

## 💡Fluxo de Teste
- Escolha uma campanha.
- Entre na tela de consultas.
- Exclua uma consulta de algum aluno.
- Se funcionou, está tudo certo!

## 💡Migrations Utilizadas
Não.

## 💡Checklist de revisão
- [ ] O número da versão foi alterado no arquivo ``` config.php ```?
- [ ] Foi adicionada uma descrição das alterações no arquivo de   ``` CHANGELOG ```?
- [ ] O pull request passou na avaliação do SonarLint?
- [x] O pull request está nomeado corretamente seguindo o padrão de nomes de branchs?
