### PR TITLE
fix/buttons-attended-delivered

### DIFF
--- a/controllers/ConsultationController.php
+++ b/controllers/ConsultationController.php
@@ -101,9 +101,9 @@ class ConsultationController extends Controller {
         $model = $this->findModel($id);
 
         if ($t == 1) {
-            $model->attended = 1;
-        } else if ($t == 2) {
-            $model->delivered = 1;
+            ($model->attended == 1) ? $model->attended = 0 : $model->attended = 1;
+        } elseif ($t == 2) {
+            ($model->delivered == 1) ? $model->delivered = 0 : $model->delivered = 1;
         }
 
         if (!$model->save()) {


### PR DESCRIPTION
## 💡Motivação
Na maioria dos alunos, não é possível marcar a opção “Compareceu” e “Recebeu”. 

Já os alunos que é possível marcar a opção “Compareceu” e “Recebeu”, não consigo desfazer a opção, caso eu marque algum aluno errado. 

## 💡Alterações Realizadas
- Modificado método de update na controller consultation, colocando um if ternário, para atualizar o valor do botão conforme apertar.

## 💡Fluxo de Testes
- Clicar no compareceu e recebeu e funcionar.

## 💡Migrations Utilizadas
Não tem.
